### PR TITLE
Fix path to built template

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ PUBLIC_URL=<%=PUBLIC_URL%>
 REACT_APP_ENV=<%-JSON.stringify(env)%>
 ```
 
-#### `dist/ng-immutable-example/index.ejs`
+#### `build/index.html`
 
 __The immutable template that is published along with the other versioned, immutable assets.__ It is combined with `config.json` to render the `index.html` that is a deployment manifest.
 


### PR DESCRIPTION
`dist/ng-immutable-example/index.ejs` is not generated by a CRA build. This was probably a copy/paste error. The actual `index.html` ejs template is output to `build/index.html`